### PR TITLE
Fix stack-use-after-scope by using value semantics

### DIFF
--- a/include/cavc/intrlineseg2lineseg2.hpp
+++ b/include/cavc/intrlineseg2lineseg2.hpp
@@ -48,12 +48,12 @@ intrLineSeg2LineSeg2(Vector2<Real> const &u1, Vector2<Real> const &u2, Vector2<R
                         Vector2<Real> const &segEnd) {
     if (utils::fuzzyEqual(segStart.x(), segEnd.x())) {
       // vertical segment, test y coordinate
-      auto minMax = std::minmax(segStart.y(), segEnd.y());
+      auto minMax = std::minmax({segStart.y(), segEnd.y()});
       return utils::fuzzyInRange(minMax.first, pt.y(), minMax.second);
     }
 
     // else just test x coordinate
-    auto minMax = std::minmax(segStart.x(), segEnd.x());
+    auto minMax = std::minmax({segStart.x(), segEnd.x()});
     return utils::fuzzyInRange(minMax.first, pt.x(), minMax.second);
   };
 


### PR DESCRIPTION
We encountered an address sanitizer finding regarding the usage of `std::minmax`. It seems `Vector2::x() const` and `Vector2::y() const` give a temporary here, for which `std::pair<const T&, const T&> minmax(const T&, const T&);` will return a reference to. Using `std::pair<T,T> minmax(std::initializer_list<T>);` (which uses values instead references) fixed the finding for us.

Maybe this is helpful for others as well :).