### PR TITLE
compile fix orgin/main for google/benchmark

### DIFF
--- a/tests/benchmarks/googlebenchmark.cmake
+++ b/tests/benchmarks/googlebenchmark.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 FetchContent_Declare(
     benchmark
     GIT_REPOSITORY       https://github.com/google/benchmark.git
-    GIT_TAG              origin/master
+    GIT_TAG              origin/main
 )
 
 fetchcontent_getproperties(benchmark)

--- a/tests/tests/staticspatialindex_tests.cpp
+++ b/tests/tests/staticspatialindex_tests.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "cavc/staticspatialindex.hpp"
 #include "testhelpers.hpp"
 #include "gmock/gmock.h"


### PR DESCRIPTION
Compile fix needed because google/benchmark changed its main branch from master to main.